### PR TITLE
Reverse specialties list in the payment form

### DIFF
--- a/src/components/forms/PaymentForm.jsx
+++ b/src/components/forms/PaymentForm.jsx
@@ -46,7 +46,7 @@ const PaymentForm = ({
 			.then(data => {
 				const list = data.filter(spec => spec.cost > 1)
 				setSpecialtiesData(list)
-				setSpecialtiesNames(list.map(specialty => specialty.title))
+				setSpecialtiesNames(list.map(specialty => specialty.title).reverse())
 			})
 			.catch(error => {
 				const { message } = { ...error.response.data }


### PR DESCRIPTION
Sorted 'higher first' to show the most pricey option at the top. Currently the easiest solution to put that on top as requested.